### PR TITLE
docs: add contributing guide with docs sync workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,30 @@
 
 We aim to keep documentation in sync with code. To achieve this without blocking PRs, we use the following workflow:
 
-1. **When making code changes**: Apply the `pending-docs-update` label to your PR
-2. **Documentation updates**: Done in weekly batches (to be automated later)
-3. **Cleanup**: Once docs are updated, the label is removed from the PR
+1. **When making code changes**: Apply the `docs:pending` label to your PR
+2. **Manual bulk processing**: Maintainers periodically review **closed** PRs with the `docs:pending` label and update docs in batches
+3. **Completion label**: After docs are updated for a PR, add `docs:updated`
+4. **Cleanup**: Remove `docs:pending` after adding `docs:updated`
 
 This approach allows code changes to land quickly while ensuring documentation stays current.
+
+### Maintainer Bulk Run Checklist
+
+Use the GitHub CLI to process closed PRs that still have `docs:pending`.
+
+1. **List candidates**
+	```bash
+	gh pr list --state closed --search 'label:"docs:pending"' --limit 200
+	```
+2. **Update documentation in bulk** based on those PRs.
+3. **Mark PRs completed** (add `docs:updated`, remove `docs:pending`):
+	```bash
+	gh pr list --state closed --search 'label:"docs:pending"' --json number --jq '.[].number' | \
+	while read -r pr; do
+	  gh pr edit "$pr" --add-label 'docs:updated' --remove-label 'docs:pending'
+	done
+	```
+4. **Verify no pending closed PRs remain**
+	```bash
+	gh pr list --state closed --search 'label:"docs:pending"' --limit 50
+	```


### PR DESCRIPTION
## Summary
- Add CONTRIBUTING.md with documentation sync workflow
- Describes using `pending-docs-update` label for PRs requiring docs updates
- Weekly batch updates will keep docs in sync with code changes