### PR TITLE
[Review Ready] Feat: Block Explorer CLI command added along with REST APIs

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,177 @@
+# 📡 API Documentation
+
+## 🚀 Run Server
+
+```bash
+cargo run -p minichain-server -- --data-dir ./data --port 3000
+```
+
+## 🔗 Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/health` | Health check |
+| GET | `/api/status` | Get chain status |
+| POST | `/api/init` | Initialize blockchain |
+| POST | `/api/account/new` | Create new account |
+| POST | `/api/account/balance` | Get account balance |
+| POST | `/api/account/info` | Get account info |
+| POST | `/api/account/list` | List all accounts |
+| POST | `/api/account/mint` | Mint tokens |
+| POST | `/api/tx/send` | Send transaction |
+| POST | `/api/tx/list` | List mempool (pending txs) |
+| POST | `/api/tx/clear` | Clear mempool |
+| POST | `/api/tx/get` | Get transaction by hash (confirmed) |
+| POST | `/api/tx/transactions` | List confirmed transactions |
+| POST | `/api/block/list` | List blocks |
+| POST | `/api/block/info` | Get block info |
+| POST | `/api/block/produce` | Produce block |
+| POST | `/api/contract/deploy` | Deploy contract |
+| POST | `/api/contract/call` | Call contract |
+
+## 🧾 Request Bodies
+
+### `/api/init`
+```json
+{
+  "data_dir": "optional",
+  "authorities": 1,
+  "block_time": 5
+}
+```
+
+### `/api/account/new`
+```json
+{
+  "data_dir": "optional",
+  "name": "alice"
+}
+```
+
+### `/api/account/balance`
+```json
+{
+  "data_dir": "optional",
+  "address": "0x..."
+}
+```
+
+### `/api/account/info`
+```json
+{
+  "data_dir": "optional",
+  "address": "0x..."
+}
+```
+
+### `/api/account/list`
+```json
+{
+  "data_dir": "optional"
+}
+```
+
+### `/api/account/mint`
+```json
+{
+  "data_dir": "optional",
+  "from": "authority_0",
+  "to": "0x...",
+  "amount": 1000
+}
+```
+
+### `/api/tx/send`
+```json
+{
+  "data_dir": "optional",
+  "from": "alice",
+  "to": "0x...",
+  "amount": 100,
+  "gas_price": 1
+}
+```
+
+### `/api/tx/list`
+```json
+{
+  "data_dir": "optional"
+}
+```
+
+### `/api/tx/clear`
+```json
+{
+  "data_dir": "optional"
+}
+```
+
+### `/api/tx/get`
+```json
+{
+  "data_dir": "optional",
+  "tx_hash": "0x..."
+}
+```
+
+### `/api/tx/transactions`
+```json
+{
+  "data_dir": "optional",
+  "count": 10
+}
+```
+
+### `/api/block/list`
+```json
+{
+  "data_dir": "optional",
+  "count": 10
+}
+```
+
+### `/api/block/info`
+```json
+{
+  "data_dir": "optional",
+  "block_id": "0"
+}
+```
+
+### `/api/block/produce`
+```json
+{
+  "data_dir": "optional",
+  "authority": "authority_0"
+}
+```
+
+### `/api/contract/deploy`
+```json
+{
+  "data_dir": "optional",
+  "from": "alice",
+  "source": "./contracts/counter.asm",
+  "gas_price": 1,
+  "gas_limit": 30000
+}
+```
+
+### `/api/contract/call`
+```json
+{
+  "data_dir": "optional",
+  "from": "alice",
+  "to": "0x...",
+  "data": "00",
+  "amount": 0,
+  "gas_price": 1
+}
+```
+
+## ⚙️ Notes
+
+- All requests accept an optional `data_dir` field  
+- `data_dir` overrides the default data directory used by the node
+- `/api/tx/list` returns pending transactions in mempool
+- `/api/tx/transactions` returns confirmed transactions in blocks

--- a/crates/cli/src/commands/block.rs
+++ b/crates/cli/src/commands/block.rs
@@ -5,10 +5,12 @@ use clap::{Args, Subcommand};
 use colored::Colorize;
 use minichain_chain::{Blockchain, BlockchainConfig};
 use minichain_consensus::{BlockProposer, PoAConfig};
-use minichain_core::{Address, Keypair};
+use minichain_core::Address;
 use minichain_storage::Storage;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use crate::alias;
 
 #[derive(Args)]
 pub struct BlockArgs {
@@ -86,7 +88,7 @@ fn list_blocks(data_dir: PathBuf, count: usize) -> Result<()> {
         println!(
             "  {} {} {}",
             format!("#{}", height).bright_black(),
-            block.hash().to_hex()[..16].bright_yellow(),
+            block.hash().to_hex().bright_yellow(),
             format!("({} txs)", block.transactions.len()).bright_black()
         );
     }
@@ -148,7 +150,7 @@ fn show_block_info(data_dir: PathBuf, block_id: String) -> Result<()> {
             println!(
                 "  {} {}",
                 format!("{}.", i + 1).bright_black(),
-                tx_hash.to_hex()[..16].bright_yellow()
+                tx_hash.to_hex().bright_yellow()
             );
         }
         println!();
@@ -161,9 +163,8 @@ fn produce_block(data_dir: PathBuf, authority_name: String) -> Result<()> {
     println!("{}", "Producing new block...".bold().cyan());
     println!();
 
-    // Load authority keypair
-    let keys_dir = data_dir.join("keys");
-    let keypair = load_keypair(&keys_dir, &authority_name)?;
+    // Load authority keypair using alias module (supports @authority_0)
+    let keypair = alias::load_keypair_by_ref(&data_dir, &authority_name)?;
     let authority_addr = keypair.address();
 
     println!("  Authority: {}", authority_addr.to_hex().bright_yellow());
@@ -211,12 +212,16 @@ fn produce_block(data_dir: PathBuf, authority_name: String) -> Result<()> {
         .propose_block(&proposer)
         .context("Failed to produce block")?;
 
-    // Import the block into the chain
+    // Import the block into the chain (this updates state_root)
     blockchain
         .import_block(block.clone())
         .context("Failed to import block")?;
 
-    let block_hash = block.hash();
+    // Retrieve the block again to get the correct hash (with updated state_root)
+    let stored_block = chain
+        .get_block_by_height(head_height + 1)?
+        .context("Block not found after import")?;
+    let block_hash = stored_block.hash();
     let new_height = head_height + 1;
 
     println!();
@@ -230,38 +235,6 @@ fn produce_block(data_dir: PathBuf, authority_name: String) -> Result<()> {
     println!();
 
     Ok(())
-}
-
-fn load_keypair(keys_dir: &Path, name: &str) -> Result<Keypair> {
-    let key_file = keys_dir.join(format!("{}.json", name));
-    if !key_file.exists() {
-        bail!(
-            "Keypair file not found: {}. Use 'minichain account new' to create one.",
-            key_file.display()
-        );
-    }
-
-    let contents = fs::read_to_string(&key_file)?;
-    let json: serde_json::Value = serde_json::from_str(&contents)?;
-
-    let private_key_hex = json
-        .get("private_key")
-        .and_then(|v| v.as_str())
-        .context("Missing private_key in keypair file")?;
-
-    let private_key_bytes = hex::decode(private_key_hex).context("Invalid private key hex")?;
-
-    if private_key_bytes.len() != 32 {
-        bail!(
-            "Invalid private key length: expected 32 bytes, got {}",
-            private_key_bytes.len()
-        );
-    }
-
-    let mut private_key = [0u8; 32];
-    private_key.copy_from_slice(&private_key_bytes);
-
-    Keypair::from_private_key(&private_key).context("Failed to create keypair from private key")
 }
 
 // Helper function to load blockchain config

--- a/crates/cli/src/commands/explore.rs
+++ b/crates/cli/src/commands/explore.rs
@@ -1,1 +1,190 @@
-//! Block explorer command.
+//! Block explorer command - Shows confirmed transactions.
+
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand};
+use colored::Colorize;
+use minichain_core::Hash;
+use minichain_storage::{ChainStore, Storage};
+use std::path::PathBuf;
+
+#[derive(Args)]
+pub struct ExploreArgs {
+    #[command(subcommand)]
+    command: Option<ExploreCommand>,
+}
+
+#[derive(Subcommand)]
+enum ExploreCommand {
+    /// Show transaction details by hash
+    Tx {
+        /// Directory to store blockchain data
+        #[arg(short, long, default_value = "./data")]
+        data_dir: PathBuf,
+
+        /// Transaction hash (hex format)
+        tx_hash: String,
+    },
+    /// Show recent transactions across all blocks
+    Transactions {
+        /// Directory to store blockchain data
+        #[arg(short, long, default_value = "./data")]
+        data_dir: PathBuf,
+
+        /// Number of transactions to show
+        #[arg(short, long, default_value = "10")]
+        count: usize,
+    },
+}
+
+pub fn run(args: ExploreArgs) -> Result<()> {
+    match args.command {
+        Some(cmd) => run_command(cmd),
+        None => run_interactive(),
+    }
+}
+
+fn run_command(cmd: ExploreCommand) -> Result<()> {
+    match cmd {
+        ExploreCommand::Tx { data_dir, tx_hash } => show_transaction(data_dir, tx_hash),
+        ExploreCommand::Transactions { data_dir, count } => list_transactions(data_dir, count),
+    }
+}
+
+fn run_interactive() -> Result<()> {
+    println!("{}", "Block Explorer".bold().cyan());
+    println!();
+    println!("Available commands:");
+    println!("  explore tx <hash>        - Show transaction details");
+    println!("  explore transactions      - List recent transactions");
+    println!();
+    println!("Examples:");
+    println!("  explore transactions --count 20");
+    println!("  explore tx 0abc123...");
+    Ok(())
+}
+
+fn show_transaction(data_dir: PathBuf, tx_hash_str: String) -> Result<()> {
+    let storage = Storage::open(&data_dir)
+        .with_context(|| "Failed to open storage. Did you run 'minichain init'?")?;
+
+    let chain = ChainStore::new(&storage);
+    let head_height = chain.get_height()?;
+
+    let tx_hash = Hash::from_hex(&tx_hash_str)
+        .with_context(|| format!("Invalid transaction hash: {}", tx_hash_str))?;
+
+    for height in 0..=head_height {
+        let block = match chain.get_block_by_height(height)? {
+            Some(b) => b,
+            None => continue,
+        };
+
+        for (i, tx) in block.transactions.iter().enumerate() {
+            if tx.hash() == tx_hash {
+                println!();
+                println!("{}", "Transaction Details:".bold().cyan());
+                println!("{}", "═".repeat(60).cyan());
+                println!();
+                println!("  {:20} {}", "Hash:".bold(), tx_hash.to_hex().yellow());
+                println!("  {:20} {}", "From:".bold(), tx.from.to_hex());
+                println!(
+                    "  {:20} {}",
+                    "To:".bold(),
+                    tx.to
+                        .map(|a| a.to_hex())
+                        .unwrap_or_else(|| "Contract Deploy".cyan().to_string())
+                );
+                println!("  {:20} {}", "Value:".bold(), tx.value);
+                println!("  {:20} {}", "Nonce:".bold(), tx.nonce);
+                println!("  {:20} {}", "Gas Limit:".bold(), tx.gas_limit);
+                println!("  {:20} {}", "Gas Price:".bold(), tx.gas_price);
+                println!();
+                println!(
+                    "  {:20} {}",
+                    "Included in:".bold(),
+                    format!("Block #{}", height).cyan()
+                );
+                println!("  {:20} {}", "Tx Index:".bold(), i);
+                println!();
+
+                if !tx.data.is_empty() {
+                    println!("  {:20}", "Calldata:".bold());
+                    let hex_str = hex::encode(&tx.data);
+                    let display = if hex_str.len() > 80 {
+                        format!("{}...", &hex_str[..80])
+                    } else {
+                        hex_str
+                    };
+                    println!("      {}", display.black());
+                    println!();
+                }
+
+                return Ok(());
+            }
+        }
+    }
+
+    bail!("Transaction not found: {}", tx_hash_str)
+}
+
+fn list_transactions(data_dir: PathBuf, count: usize) -> Result<()> {
+    let storage = Storage::open(&data_dir)
+        .with_context(|| "Failed to open storage. Did you run 'minichain init'?")?;
+
+    let chain = ChainStore::new(&storage);
+    let head_height = chain.get_height()?;
+
+    println!();
+    println!("{}", "Recent Transactions:".bold().cyan());
+    println!("{}", "═".repeat(70).cyan());
+    println!();
+    println!(
+        "  {:>6} {:<18} {:<10} {:<10} {}",
+        "Block".bold(),
+        "Tx Hash".bold(),
+        "From".bold(),
+        "To".bold(),
+        "Value".bold()
+    );
+    println!("{}", "─".repeat(70).cyan());
+
+    let mut txs: Vec<(u64, minichain_core::Transaction)> = Vec::new();
+
+    for height in (0..=head_height).rev() {
+        if let Some(block) = chain.get_block_by_height(height)? {
+            for tx in block.transactions {
+                txs.push((height, tx));
+                if txs.len() >= count {
+                    break;
+                }
+            }
+        }
+        if txs.len() >= count {
+            break;
+        }
+    }
+
+    for (height, tx) in &txs {
+        let from = tx.from.to_hex();
+        let to = tx
+            .to
+            .map(|a| a.to_hex())
+            .unwrap_or_else(|| "Contract Deploy".to_string());
+
+        println!(
+            "  {:>6} {} {} {} {}",
+            height.to_string().cyan(),
+            tx.hash().to_hex().yellow(),
+            from,
+            to,
+            tx.value
+        );
+    }
+
+    if txs.is_empty() {
+        println!("  (no transactions found)");
+    }
+
+    println!();
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -26,7 +26,7 @@ pub enum Commands {
     /// Call a contract
     Call(call::CallArgs),
     /// Block explorer
-    Explore,
+    Explore(explore::ExploreArgs),
 }
 
 pub fn run(cmd: Commands) -> Result<()> {
@@ -37,9 +37,6 @@ pub fn run(cmd: Commands) -> Result<()> {
         Commands::Block(args) => block::run(args),
         Commands::Deploy(args) => deploy::run(args),
         Commands::Call(args) => call::run(args),
-        Commands::Explore => {
-            println!("explore: not yet implemented");
-            Ok(())
-        }
+        Commands::Explore(args) => explore::run(args),
     }
 }

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -303,6 +303,74 @@ pub fn list_mempool(data_dir: &Path) -> Result<Vec<TransactionInfo>> {
     Ok(transactions)
 }
 
+pub fn get_transaction(data_dir: &Path, tx_hash: &str) -> Result<TransactionInfo> {
+    let tx_hash = Hash::from_hex(tx_hash).context("Invalid transaction hash")?;
+    let storage = Storage::open(data_dir)?;
+    let chain = ChainStore::new(&storage);
+    let head_height = chain.get_height()?;
+
+    for height in 0..=head_height {
+        let block = match chain.get_block_by_height(height)? {
+            Some(b) => b,
+            None => continue,
+        };
+
+        for tx in block.transactions.iter() {
+            if tx.hash() == tx_hash {
+                return Ok(TransactionInfo {
+                    hash: tx.hash().to_hex(),
+                    from: tx.from.to_hex(),
+                    to: tx.to.map(|a| a.to_hex()),
+                    value: tx.value.to_string(),
+                    nonce: tx.nonce,
+                    data: if tx.data.is_empty() {
+                        None
+                    } else {
+                        Some(hex::encode(&tx.data))
+                    },
+                });
+            }
+        }
+    }
+
+    anyhow::bail!("Transaction not found")
+}
+
+pub fn list_transactions(data_dir: &Path, count: usize) -> Result<Vec<TransactionInfo>> {
+    let storage = Storage::open(data_dir)?;
+    let chain = ChainStore::new(&storage);
+    let head_height = chain.get_height()?;
+
+    let mut txs: Vec<TransactionInfo> = Vec::new();
+
+    for height in (0..=head_height).rev() {
+        if let Some(block) = chain.get_block_by_height(height)? {
+            for tx in block.transactions {
+                txs.push(TransactionInfo {
+                    hash: tx.hash().to_hex(),
+                    from: tx.from.to_hex(),
+                    to: tx.to.map(|a| a.to_hex()),
+                    value: tx.value.to_string(),
+                    nonce: tx.nonce,
+                    data: if tx.data.is_empty() {
+                        None
+                    } else {
+                        Some(hex::encode(&tx.data))
+                    },
+                });
+                if txs.len() >= count {
+                    break;
+                }
+            }
+        }
+        if txs.len() >= count {
+            break;
+        }
+    }
+
+    Ok(txs)
+}
+
 pub fn clear_mempool(data_dir: &Path) -> Result<String> {
     let storage = Storage::open(data_dir)?;
     let db = storage.inner();

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -79,6 +79,18 @@ struct ListAccountsRequest {
 }
 
 #[derive(serde::Deserialize)]
+struct TxListRequest {
+    data_dir: Option<String>,
+    count: Option<usize>,
+}
+
+#[derive(serde::Deserialize)]
+struct TxGetRequest {
+    data_dir: Option<String>,
+    tx_hash: String,
+}
+
+#[derive(serde::Deserialize)]
 struct MintRequest {
     data_dir: Option<String>,
     from: String,
@@ -176,6 +188,8 @@ async fn main() {
         .route("/api/tx/send", post(send_transaction))
         .route("/api/tx/list", post(list_mempool))
         .route("/api/tx/clear", post(clear_mempool))
+        .route("/api/tx/get", post(get_transaction))
+        .route("/api/tx/transactions", post(list_transactions))
         .route("/api/block/list", post(list_blocks))
         .route("/api/block/info", post(block_info))
         .route("/api/block/produce", post(produce_block))
@@ -350,7 +364,7 @@ async fn send_transaction(
 
 async fn list_mempool(
     State(state): State<AppState>,
-    Json(req): Json<ListAccountsRequest>,
+    Json(req): Json<TxListRequest>,
 ) -> Json<ApiResponse<Vec<TransactionInfo>>> {
     let data_dir = get_data_dir(&req.data_dir, &state.data_dir);
     match api::list_mempool(&data_dir) {
@@ -361,11 +375,34 @@ async fn list_mempool(
 
 async fn clear_mempool(
     State(state): State<AppState>,
-    Json(req): Json<ListAccountsRequest>,
+    Json(req): Json<TxListRequest>,
 ) -> Json<ApiResponse<String>> {
     let data_dir = get_data_dir(&req.data_dir, &state.data_dir);
     match api::clear_mempool(&data_dir) {
         Ok(result) => Json(ApiResponse::ok(result)),
+        Err(e) => Json(ApiResponse::err(e.to_string())),
+    }
+}
+
+async fn get_transaction(
+    State(state): State<AppState>,
+    Json(req): Json<TxGetRequest>,
+) -> Json<ApiResponse<TransactionInfo>> {
+    let data_dir = get_data_dir(&req.data_dir, &state.data_dir);
+    match api::get_transaction(&data_dir, &req.tx_hash) {
+        Ok(info) => Json(ApiResponse::ok(info)),
+        Err(e) => Json(ApiResponse::err(e.to_string())),
+    }
+}
+
+async fn list_transactions(
+    State(state): State<AppState>,
+    Json(req): Json<TxListRequest>,
+) -> Json<ApiResponse<Vec<TransactionInfo>>> {
+    let data_dir = get_data_dir(&req.data_dir, &state.data_dir);
+    let count = req.count.unwrap_or(10);
+    match api::list_transactions(&data_dir, count) {
+        Ok(txs) => Json(ApiResponse::ok(txs)),
         Err(e) => Json(ApiResponse::err(e.to_string())),
     }
 }

--- a/packages/minichain-contract-test-harness/src/index.ts
+++ b/packages/minichain-contract-test-harness/src/index.ts
@@ -83,7 +83,7 @@ export async function produceBlock(dataDir: string): Promise<void> {
   if (SKIP_BLOCK_PRODUCTION) {
     return;
   }
-  await runMinichain("block", "produce", "--authority", "authority_0", "--data-dir", dataDir);
+  await runMinichain("block", "produce", "--authority", "@authority_0", "--data-dir", dataDir);
 }
 
 export async function getBalance(dataDir: string, address: string): Promise<number> {


### PR DESCRIPTION
## Summary
Introduces a **Block Explorer** feature to `minichain`, allowing users to query confirmed transactions across all blocks via both **CLI** and **REST API**.

---

## Changes

### CLI — Added explore command

| Command | Description |
|--------|------------|
| `explore transactions` | List recent confirmed transactions across all blocks |
| `explore tx <hash>` | Fetch transaction details by hash |

---

### 🔹 CLI — Improvements
- ✅ **Fixed a bug causing block hash display incorrectly (old state_root used)**  
  `block produce` now shows the correct block hash (previously incorrect). This was just a display bug, not a system/consistency bug.

- ✅ **Alias support added in "block produce"**  
  ```
  cargo run --release -p minichain-cli -- block produce --authority @authority_0
  ```
  now works (previously only `authority_0`)

- ✅ **Full hash display**  
  `block list` and `explore transactions` now show full **64-character hashes** instead of truncated versions

---

### 🌐 REST API — New Endpoints

| Endpoint | Method | Description |
|----------|--------|------------|
| `/api/tx/get` | POST | Get transaction details by hash |
| `/api/tx/transactions` | POST | List confirmed transactions across all blocks |

---

---

## 🧪 Example Usage

```bash
# CLI — List recent transactions
cargo run --release -p minichain-cli -- explore transactions --count 20

# CLI — Get transaction by hash
cargo run --release -p minichain-cli -- explore tx 0xabc123...

# CLI — Produce block with alias
cargo run --release -p minichain-cli -- block produce --authority @authority_0

# API — List transactions
curl -X POST http://localhost:3000/api/tx/transactions \
  -d '{"count": 10}'

# API — Get transaction
curl -X POST http://localhost:3000/api/tx/get \
  -d '{"tx_hash": "0xabc123..."}'
```

---

### 📚 Documentation
- Added `API.md` with complete REST API documentation

---

## 📁 Files Changed

| File | Description |
|------|------------|
| `crates/cli/src/commands/explore.rs` | New implementation (+191 lines) |
| `crates/cli/src/commands/mod.rs` | Added Explore command routing |
| `crates/cli/src/commands/block.rs` | Fixed hash display, added alias support |
| `crates/server/src/api.rs` | Added `get_transaction()` and `list_transactions()` |
| `crates/server/src/main.rs` | Added routes for new endpoints |
| `API.md` | New API documentation |

---

## ✅ Testing
- All existing unit tests pass
- CLI and API return consistent results using manual testings and AI assisted testings